### PR TITLE
Support order on scripts, default to line number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ $RECYCLE.BIN/
 /Libs
 /NuGet/tools/lib
 /NuGet/*.nupkg
+/.vs/

--- a/PowerShellActions/CustomAction.cs
+++ b/PowerShellActions/CustomAction.cs
@@ -92,7 +92,7 @@ namespace PowerShellActions
             try
             {
                 List<ScriptActionData> scripts = new List<ScriptActionData>();
-                using (View view = db.OpenView(string.Format("SELECT `Id`, `Script`, `IgnoreErrors` FROM `PowerShellScripts` WHERE `Elevated` = {0}", elevated)))
+                using (View view = db.OpenView(string.Format("SELECT `Id`, `Script`, `IgnoreErrors` FROM `PowerShellScripts` WHERE `Elevated` = {0} ORDER BY `Order`", elevated)))
                 {
                     view.Execute();
 
@@ -254,7 +254,7 @@ namespace PowerShellActions
             try
             {
                 XDocument doc;
-                using (View view = db.OpenView(string.Format("SELECT `Id`, `File`, `Arguments`, `IgnoreErrors` FROM `{0}` WHERE `Elevated` = {1}", tableName, elevated)))
+                using (View view = db.OpenView(string.Format("SELECT `Id`, `File`, `Arguments`, `IgnoreErrors` FROM `{0}` WHERE `Elevated` = {1} ORDER BY `Order`", tableName, elevated)))
                 {
                     view.Execute();
 

--- a/PowerShellWixExtension/PowerShellCompilerExtension.cs
+++ b/PowerShellWixExtension/PowerShellCompilerExtension.cs
@@ -61,6 +61,7 @@ namespace PowerShellWixExtension
             string arguments = null;
             var elevated = YesNoType.No;
             YesNoType ignoreErrors = YesNoType.No;
+            int order = 1000000000 + sourceLineNumber[0].LineNumber;
 
             foreach (XmlAttribute attribute in node.Attributes)
             {
@@ -83,6 +84,9 @@ namespace PowerShellWixExtension
                             break;
                         case "IgnoreErrors":
                             ignoreErrors = Core.GetAttributeYesNoValue(sourceLineNumber, attribute);
+                            break;
+                        case "Order":
+                            order = Core.GetAttributeIntegerValue(sourceLineNumber, attribute, 0, 1000000000);
                             break;
                         default:
                             Core.UnexpectedAttribute(sourceLineNumber, attribute);
@@ -116,6 +120,7 @@ namespace PowerShellWixExtension
                 superElementRow[2] = arguments;
                 superElementRow[3] = elevated == YesNoType.Yes ? 1 : 0;
                 superElementRow[4] = (ignoreErrors == YesNoType.Yes) ? 1 : 0;
+                superElementRow[5] = order;
             }
 
             Core.CreateWixSimpleReferenceRow(sourceLineNumber, "CustomAction", "PowerShellFilesImmediate");
@@ -129,6 +134,7 @@ namespace PowerShellWixExtension
             string scriptData = null;
             var elevated = YesNoType.No;
             YesNoType ignoreErrors = YesNoType.No;
+            int order = 1000000000 + sourceLineNumber[0].LineNumber;
 
             foreach (XmlAttribute attribute in node.Attributes)
             {
@@ -145,6 +151,9 @@ namespace PowerShellWixExtension
                             break;
                         case "IgnoreErrors":
                             ignoreErrors = Core.GetAttributeYesNoValue(sourceLineNumber, attribute);
+                            break;
+                        case "Order":
+                            order = Core.GetAttributeIntegerValue(sourceLineNumber, attribute, 0, 1000000000);
                             break;
 
                         default:
@@ -186,6 +195,7 @@ namespace PowerShellWixExtension
                 superElementRow[1] = scriptData;
                 superElementRow[2] = elevated == YesNoType.Yes ? 1 : 0;
                 superElementRow[3] = (ignoreErrors == YesNoType.Yes) ? 1 : 0;
+                superElementRow[4] = order;
             }
 
             Core.CreateWixSimpleReferenceRow(sourceLineNumber, "CustomAction", "PowerShellScriptsImmediate");

--- a/PowerShellWixExtension/PowerShellWixExtensionSchema.xsd
+++ b/PowerShellWixExtension/PowerShellWixExtensionSchema.xsd
@@ -48,6 +48,12 @@
               <xs:documentation>Set to true to ignore PowerShell errors</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+
+          <xs:attribute name="Order" use="optional" type="xs:int">
+            <xs:annotation>
+              <xs:documentation>Order of script execution. Note that ordering is within the context and type. For example, elevated scripts will run on different context than non-elevated. Defaults to run in line-number order. Files with explicit ordering will be executed before files with implicit ordering</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
         
         </xs:extension>       
       </xs:simpleContent>
@@ -97,6 +103,12 @@
       <xs:attribute name="IgnoreErrors" use="optional" default="no" type="wix:YesNoType">
         <xs:annotation>
           <xs:documentation>Set to true to ignore PowerShell errors</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="Order" use="optional" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>Order of script execution. Note that ordering is within the context and type. For example, elevated scripts will run on different context than non-elevated. Defaults to run in line-number order. Files with explicit ordering will be executed before files with implicit ordering</xs:documentation>
         </xs:annotation>
       </xs:attribute>
 

--- a/PowerShellWixExtension/Properties/AssemblyInfo.cs
+++ b/PowerShellWixExtension/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using Microsoft.Tools.WindowsInstallerXml;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 
 [assembly: AssemblyDefaultWixExtension(typeof(PowerShellWixExtension.PowerShellWixExtension))]

--- a/PowerShellWixExtension/TableDefinitions.xml
+++ b/PowerShellWixExtension/TableDefinitions.xml
@@ -29,6 +29,7 @@
       description="Run as elevated" />
 
     <columnDefinition name="IgnoreErrors" type="number" category="integer" length="0" minValue="0" maxValue="1" nullable="no" description="When non-zero, PowerShell errors are ignored." />
+    <columnDefinition name="Order" type="number" category="integer" length="4" minValue="0" maxValue="2000000000" nullable="no" description="Order of execution." />
 
   </tableDefinition>
 
@@ -73,6 +74,7 @@
   nullable="no"
   description="When non-zero, PowerShell errors are ignored." />
 
+    <columnDefinition name="Order" type="number" category="integer" length="4" minValue="0" maxValue="2000000000" nullable="no" description="Order of execution." />
   </tableDefinition>
 
 </tableDefinitions>


### PR DESCRIPTION
Allow to specify Order attribute on PS scripts.
Order will apply for scripts in the same context (elevated / impersonated) and type (script / file)
Defaults to line number
Scripts with explicit ordering will be executed before scripts with implicit (line number) order.